### PR TITLE
Commit Version Bug Fix

### DIFF
--- a/training/fine-tune-llms-in-2024-with-trl.ipynb
+++ b/training/fine-tune-llms-in-2024-with-trl.ipynb
@@ -60,12 +60,8 @@
     "  \"accelerate==0.26.1\" \\\n",
     "  \"evaluate==0.4.1\" \\\n",
     "  \"bitsandbytes==0.42.0\" \\\n",
-    "  # \"trl==0.7.10\" # \\\n",
-    "  # \"peft==0.7.1\" \\\n",
-    "\n",
-    "# install peft & trl from github\n",
-    "!pip install git+https://github.com/huggingface/trl@a3c5b7178ac4f65569975efadc97db2f3749c65e --upgrade\n",
-    "!pip install git+https://github.com/huggingface/peft@4a1559582281fc3c9283892caea8ccef1d6f5a4f--upgrade"
+    "  \"trl==0.7.10\" # \\\n",
+    "  \"peft==0.7.1\" \\"
    ]
   },
   {
@@ -262,7 +258,10 @@
     "\n",
     "# BitsAndBytesConfig int-4 config\n",
     "bnb_config = BitsAndBytesConfig(\n",
-    "    load_in_4bit=True, bnb_4bit_use_double_quant=True, bnb_4bit_quant_type=\"nf4\", bnb_4bit_compute_dtype=torch.bfloat16\n",
+    "    load_in_4bit=True, \n",
+    "    bnb_4bit_use_double_quant=True, \n",
+    "    bnb_4bit_quant_type=\"nf4\", \n",
+    "    bnb_4bit_compute_dtype=torch.bfloat16\n",
     ")\n",
     "\n",
     "# Load model and tokenizer\n",
@@ -294,6 +293,28 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# In the next version Lora you can use \"all-linear\"\n",
+    "# Here Get all linear for target modules\n",
+    "def find_all_linear_names(model):\n",
+    "    cls = bnb.nn.Linear4bit  # (default:torch.nn.Linear,4bit:bnb.nn.Linear4bit,8bit:bnb.nn.Linear8bitLt)\n",
+    "    lora_module_names = set()\n",
+    "    for name, module in model.named_modules():\n",
+    "        if isinstance(module, cls):\n",
+    "            names = name.split('.')\n",
+    "            lora_module_names.add(names[0] if len(names) == 1 else names[-1])\n",
+    "\n",
+    "\n",
+    "    if 'lm_head' in lora_module_names: # needed for 16-bit\n",
+    "        lora_module_names.remove('lm_head')\n",
+    "    return list(lora_module_names)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "from peft import LoraConfig\n",
     "\n",
     "# LoRA config based on QLoRA paper & Sebastian Raschka experiment\n",
@@ -302,7 +323,7 @@
     "        lora_dropout=0.05,\n",
     "        r=256,\n",
     "        bias=\"none\",\n",
-    "        target_modules=\"all-linear\",\n",
+    "        target_modules=find_all_linear_names(model),\n",
     "        task_type=\"CAUSAL_LM\", \n",
     ")"
    ]
@@ -338,6 +359,7 @@
     "    max_grad_norm=0.3,                      # max gradient norm based on QLoRA paper\n",
     "    warmup_ratio=0.03,                      # warmup ratio based on QLoRA paper\n",
     "    lr_scheduler_type=\"constant\",           # use constant learning rate scheduler\n",
+    "    group_by_length=True,                   # Group sequences into batches with same length (Saves memory and speeds up training)\n",
     "    push_to_hub=True,                       # push model to hub\n",
     "    report_to=\"tensorboard\",                # report metrics to tensorboard\n",
     ")"
@@ -475,20 +497,38 @@
    "outputs": [],
    "source": [
     "import torch\n",
-    "from peft import AutoPeftModelForCausalLM\n",
-    "from transformers import AutoTokenizer, pipeline \n",
+    "from transformers import AutoTokenizer, pipeline, AutoModelForCausalLM\n",
     "\n",
     "peft_model_id = \"./code-llama-7b-text-to-sql\"\n",
     "# peft_model_id = args.output_dir\n",
     "\n",
-    "# Load Model with PEFT adapter\n",
-    "model = AutoPeftModelForCausalLM.from_pretrained(\n",
-    "  peft_model_id,\n",
+    "# Load Perf Config and tokenizer\n",
+    "tokenizer = AutoTokenizer.from_pretrained(peft_model_id)\n",
+    "config = PeftConfig.from_pretrained(peft_model_id)\n",
+    "\n",
+    "# Load Model with Base model\n",
+    "model = AutoModelForCausalLM.from_pretrained(\n",
+    "  config.base_model_name_or_path,\n",
     "  device_map=\"auto\",\n",
     "  torch_dtype=torch.float16\n",
     ")\n",
+    "\n",
+    "model.resize_token_embeddings(len(tokenizer))\n",
+    "model = PeftModel.from_pretrained(model, peft_model_id)\n",
     "# load into pipeline\n",
-    "pipe = pipeline(\"text-generation\", model=model, tokenizer=tokenizer)"
+    "pipe = pipeline(\"text-generation\", model=model, tokenizer=tokenizer)\n",
+    "\n",
+    "\n",
+    "# Note in the next version your can:\n",
+    "# from peft import AutoPeftModelForCausalLM\n",
+    "#\n",
+    "# Load Model with PEFT adapter\n",
+    "# model = AutoPeftModelForCausalLM.from_pretrained(\n",
+    "#  peft_model_id,\n",
+    "#  device_map=\"auto\",\n",
+    "#  torch_dtype=torch.float16\n",
+    "# )\n",
+    "# pipe = pipeline(\"text-generation\", model=model, tokenizer=tokenizer)"
    ]
   },
   {


### PR DESCRIPTION
This pull request addresses and fixes the issues associated with commit versions.

Previously, relying on commit versions posed problems, with some being merged and potentially causing functionality issues.

Furthermore, this update incorporates a detailed comment to assist users in effectively leveraging the code in future versions.

Previously, the code was triggering the following error:

```
opt/conda/lib/python3.10/site-packages/transformers/generation/configuration_utils.py:389: UserWarning: `do_sample` is set to `False`. However, `temperature` is set to `0.1` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `temperature`.
  warnings.warn(
/opt/conda/lib/python3.10/site-packages/transformers/generation/configuration_utils.py:394: UserWarning: `do_sample` is set to `False`. However, `top_p` is set to `0.1` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `top_p`.
  warnings.warn(
../aten/src/ATen/native/cuda/Indexing.cu:1292: indexSelectLargeIndex: block: [262,0,0], thread: [32,0,0] Assertion `srcIndex < srcSelectDimSize` failed.
../aten/src/ATen/native/cuda/Indexing.cu:1292: indexSelectLargeIndex: block: [262,0,0], thread: [33,0,0] Assertion `srcIndex < srcSelectDimSize` failed.
../aten/src/ATen/native/cuda/Indexing.cu:1292: indexSelectLargeIndex: block: [262,0,0], thread: [34,0,0] Assertion `srcIndex < srcSelectDimSize` failed.
../aten/src/ATen/native/cuda/Indexing.cu:1292: indexSelectLargeIndex: block: [262,0,0], thread: [35,0,0] Assertion `srcIndex < srcSelectDimSize` failed.
../aten/src/ATen/native/cuda/Indexing.cu:1292: indexSelectLargeIndex: block: [262,0,0], thread: [36,0,0] Assertion `srcIndex < srcSelectDimSize` failed.

File /opt/conda/lib/python3.10/site-packages/transformers/modeling_attn_mask_utils.py:343, in _prepare_4d_causal_attention_mask_for_sdpa(attention_mask, input_shape, inputs_embeds, past_key_values_length, sliding_window)
    340 is_tracing = torch.jit.is_tracing()
    342 if attention_mask is not None:
--> 343     if torch.all(attention_mask == 1):
    344         if is_tracing:
    345             pass

RuntimeError: CUDA error: device-side assert triggered
CUDA kernel errors might be asynchronously reported at some other API call, so the stacktrace below might be incorrect.
For debugging consider passing CUDA_LAUNCH_BLOCKING=1.
Compile with `TORCH_USE_CUDA_DSA` to enable device-side assertions.
```