### PR TITLE
Clean up some typos; simplify some code; update some comments

### DIFF
--- a/training/fine-tune-embedding-model-for-rag.ipynb
+++ b/training/fine-tune-embedding-model-for-rag.ipynb
@@ -33,7 +33,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Before we can get started we need to install Hugging Face Libraries and Pyroch, including Sentence Transformers, transformers and datasets."
+    "Before we can get started we need to install Hugging Face Libraries and Pytorch, including Sentence Transformers, transformers and datasets."
    ]
   },
   {
@@ -100,7 +100,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We are going to load our open-source dataset using the 🤗 Datasets library, rename the colums to match what `sentence-transforemrs` expects and then split our dataset into a train and test spilt to be able to evaluate our model. "
+    "We are going to load our open-source dataset using the 🤗 Datasets library and split our dataset into a train and test split to be able to evaluate our model. "
    ]
   },
   {
@@ -114,19 +114,8 @@
     "# Load dataset from the hub\n",
     "dataset = load_dataset(\"philschmid/finanical-rag-embedding-dataset\", split=\"train\")\n",
     "\n",
-    "# rename columns\n",
-    "dataset = dataset.rename_column(\"question\", \"anchor\")\n",
-    "dataset = dataset.rename_column(\"context\", \"positive\")\n",
-    "\n",
-    "\n",
-    "# Create an ID column\n",
-    "def add_id_column(sample, idx):\n",
-    "    sample[\"id\"] = idx\n",
-    "    return sample\n",
-    "\n",
-    "\n",
-    "# Map the function to the dataset\n",
-    "dataset = dataset.map(add_id_column, with_indices=True)\n",
+    "# Add an id column to the dataset\n",
+    "dataset = dataset.add_column(\"id\", range(len(dataset)))\n",
     "\n",
     "# split dataset into a 10% test set\n",
     "dataset = dataset.train_test_split(test_size=0.1)\n",
@@ -169,7 +158,7 @@
     "from datasets import load_dataset, concatenate_datasets\n",
     "\n",
     "model_id = \"BAAI/bge-base-en-v1.5\"  # Hugging Face model ID\n",
-    "matryoshka_dimensions = [768, 512, 256, 128, 64]  # important order is reversed\n",
+    "matryoshka_dimensions = [768, 512, 256, 128, 64]  # important: large to small\n",
     "\n",
     "# Load a model\n",
     "model = SentenceTransformer(\n",
@@ -181,19 +170,14 @@
     "train_dataset = load_dataset(\"json\", data_files=\"train_dataset.json\", split=\"train\")\n",
     "corpus_dataset = concatenate_datasets([train_dataset, test_dataset])\n",
     "\n",
-    "# Convert the datasets to dictionaries\n",
-    "corpus = dict(\n",
-    "    zip(corpus_dataset[\"id\"], corpus_dataset[\"positive\"])\n",
-    ")  # Our corpus (cid => document)\n",
-    "queries = dict(\n",
-    "    zip(test_dataset[\"id\"], test_dataset[\"anchor\"])\n",
-    ")  # Our queries (qid => question)\n",
+    "# Convert the datasets to dictionaries, corpus (cid => document) and queries (qid => question)\n",
+    "# Note that we use the full corpus, but only the test set queries\n",
+    "corpus = dict(zip(corpus_dataset[\"id\"], corpus_dataset[\"question\"]))\n",
+    "queries = dict(zip(test_dataset[\"id\"], test_dataset[\"context\"]))\n",
     "\n",
-    "# Create a mapping of relevant document (1 in our case) for each query\n",
-    "relevant_docs = {}  # Query ID to relevant documents (qid => set([relevant_cids])\n",
-    "for q_id in queries:\n",
-    "    relevant_docs[q_id] = [q_id]\n",
-    "\n",
+    "# Create a mapping of relevant document ids for each query: (qid => set([relevant_cids])\n",
+    "# We only have 1 relevant document per query, so we always map query ID i to document ID i\n",
+    "relevant_docs = {idx: [idx] for idx in queries}\n",
     "\n",
     "matryoshka_evaluators = []\n",
     "# Iterate over the different dimensions\n",
@@ -202,7 +186,7 @@
     "        queries=queries,\n",
     "        corpus=corpus,\n",
     "        relevant_docs=relevant_docs,\n",
-    "        name=f\"basline_{dim}\",\n",
+    "        name=f\"financial_{dim}\",\n",
     "        truncate_dim=dim,  # Truncate the embeddings to a certain dimension\n",
     "        score_functions={\"cosine\": cos_sim},\n",
     "    )\n",
@@ -233,8 +217,7 @@
     "\n",
     "# Print the main score\n",
     "for dim in matryoshka_dimensions:\n",
-    "    key = f\"basline_{dim}_cosine_ndcg@10\"\n",
-    "    print\n",
+    "    key = f\"financial_{dim}_cosine_ndcg@10\"\n",
     "    print(f\"{key}: {results[key]}\")"
    ]
   },
@@ -242,12 +225,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Great our default baseline with the [BAAI/bge-base-en-v1.5](https://huggingface.co/BAAI/bge-base-en-v1.5) are:\n",
-    "- dim 768: `0.7683576219287339`\n",
-    "- dim 512: `0.7642500951356254`\n",
-    "- dim 256: `0.7546468566985919`\n",
-    "- dim 128: `0.7233663127615272`\n",
-    "- dim 64: `0.6439999058834552`\n",
+    "Great, our baseline scores with the [BAAI/bge-base-en-v1.5](https://huggingface.co/BAAI/bge-base-en-v1.5) are:\n",
+    "- dim 768: `0.7683576219287339` NDCG@10\n",
+    "- dim 512: `0.7642500951356254` NDCG@10\n",
+    "- dim 256: `0.7546468566985919` NDCG@10\n",
+    "- dim 128: `0.7233663127615272` NDCG@10\n",
+    "- dim 64: `0.6439999058834552` NDCG@10\n",
     "\n",
     "Now, let's see if we can improve this score by fine-tuning the model on our specific dataset."
    ]
@@ -276,7 +259,8 @@
    "source": [
     "from sentence_transformers import SentenceTransformerModelCardData, SentenceTransformer\n",
     "\n",
-    "model_id = \"BAAI/bge-base-en-v1.5\"  # Hugging Face model ID\n",
+    "# Hugging Face model ID: https://huggingface.co/BAAI/bge-base-en-v1.5\n",
+    "model_id = \"BAAI/bge-base-en-v1.5\"\n",
     "\n",
     "# load model with SDPA for using Flash Attention 2\n",
     "model = SentenceTransformer(\n",
@@ -305,7 +289,7 @@
    "source": [
     "from sentence_transformers.losses import MatryoshkaLoss, MultipleNegativesRankingLoss\n",
     "\n",
-    "matryoshka_dimensions = [768, 512, 256, 128, 64]  # important order is reversed\n",
+    "matryoshka_dimensions = [768, 512, 256, 128, 64]  # important: large to small\n",
     "inner_train_loss = MultipleNegativesRankingLoss(model)\n",
     "train_loss = MatryoshkaLoss(\n",
     "    model, inner_train_loss, matryoshka_dims=matryoshka_dimensions\n",
@@ -374,11 +358,14 @@
     "from sentence_transformers import SentenceTransformerTrainer\n",
     "\n",
     "trainer = SentenceTransformerTrainer(\n",
-    "    model=model, # bg-base-en-v1\n",
+    "    model=model, # bge-base-en-v1\n",
     "    args=args,  # training arguments\n",
     "    train_dataset=train_dataset.select_columns(\n",
-    "        [\"positive\", \"anchor\"]\n",
-    "    ),  # training dataset\n",
+    "        [\"question\", \"context\"]\n",
+    "    ),  # training dataset, we select only required columns\n",
+    "    eval_dataset=test_dataset.select_columns(\n",
+    "        [\"question\", \"context\"]\n",
+    "    ),  # evaluation dataset, we select only required columns\n",
     "    loss=train_loss,\n",
     "    evaluator=evaluator,\n",
     ")"
@@ -443,7 +430,7 @@
     "\n",
     "# Print the main score\n",
     "for dim in matryoshka_dimensions:\n",
-    "    key = f\"basline_{dim}_cosine_ndcg@10\"\n",
+    "    key = f\"financial_{dim}_cosine_ndcg@10\"\n",
     "    print(f\"{key}: {results[key]}\")"
    ]
   },
@@ -452,11 +439,11 @@
    "metadata": {},
    "source": [
     "Our fine-tuned model achieves:\n",
-    "- dim 768: `0.8253652077429072`\n",
-    "- dim 512: `0.8274643684492735`\n",
-    "- dim 256: `0.8230326345640168`\n",
-    "- dim 128: `0.8184049256658124`\n",
-    "- dim 64: `0.7892150398663841`\n",
+    "- dim 768: `0.8253652077429072` NDCG@10\n",
+    "- dim 512: `0.8274643684492735` NDCG@10\n",
+    "- dim 256: `0.8230326345640168` NDCG@10\n",
+    "- dim 128: `0.8184049256658124` NDCG@10\n",
+    "- dim 64: `0.7892150398663841` NDCG@10\n",
     "\n",
     "Lets put this into a table and compare the performance of our fine-tuned model against the baseline.\n",
     "\n",
@@ -471,7 +458,7 @@
     "Lets try to understand this: \n",
     "* Fine-tuned model outperforms the baseline model in all dimensions. \n",
     "* BGE base is already a very strong base model but fine-tuning it on only 6.3k samples still improves performance by ~7.4%.\n",
-    "* Matryoshka representation learning works and keeps 95% performance at 64 dimensions (12x size reduction), 99% at 128 dimensions (7x site reduction), >99.5% at 256 dimensions (3x size reduction). \n",
+    "* Matryoshka representation learning works and keeps 95% performance at 64 dimensions (12x size reduction), 99% at 128 dimensions (7x size reduction), >99.5% at 256 dimensions (3x size reduction). \n",
     "* The Fine-tuned model with lowest dimension (64) outperforms the baseline model with highest dimensions (768). \n",
     "* Optimizing the model dimension of 128 allows us to keep 99% of the performance of the 768 dimension model but reducing the storing cost by 6x and improving the cosine similarity search. \n",
     "* The fine-tuned model with 128 dimensions outperforms the baseline model with 768 dimensions by 6.51%, while being 6x smaller.\n",
@@ -486,7 +473,7 @@
     "\n",
     "Embedding models are crucial for successfull RAG applications, since if you don't retrieve the right context you can't generate the right answer. Customizing embedding models for domain-specific data can improve retrieval performance significantly compared to using general knowledge models. Fine-tuning embedding models has become highly accessible, and using synthetic data generated by LLMs, one can easily customize models for specific needs, resulting in substantial improvements.\n",
     "\n",
-    "Our results show that fine-tuning can boost performance by ~7% only 6.3k sample. The training took 3 minutes on a consumer size GPU and by leveraging modern techniques like Matryoshka Representation Learning we achieved over 99% performance retention with 6x storage reduction and efficiency gains."
+    "Our results show that fine-tuning can boost performance by ~7% with only 6.3k samples. The training took 3 minutes on a consumer size GPU and by leveraging modern techniques like Matryoshka Representation Learning we achieved over 99% performance retention with 6x storage reduction and efficiency gains."
    ]
   },
   {
@@ -511,7 +498,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.13"
+   "version": "3.11.6"
   },
   "orig_nbformat": 4,
   "vscode": {


### PR DESCRIPTION
Hello!

## Pull Request overview
* Clean up some typos
* Simplify some code
* Update some comments
* Rename basline -> financial

## Details
I ended up not changing the learning rate/batch size, etc., as I was unable to reproduce your findings exactly (due to the train_test method giving me different testing queries).

I also renamed "baseline" as we use it throughout the entire script, both for the baseline but also during training and after training. So I turned it into "financial" instead.

And I undid the column renaming: that's not necessary in Sentence Transformers. The columns are used in order, regardless of the names. 

cc @philschmid 

- Tom Aarsen