### PR TITLE
[`embeddings`] Update (positive, anchor) to (anchor, positive)

### DIFF
--- a/training/fine-tune-embedding-model-for-rag.ipynb
+++ b/training/fine-tune-embedding-model-for-rag.ipynb
@@ -371,7 +371,7 @@
     "    model=model, # bg-base-en-v1\n",
     "    args=args,  # training arguments\n",
     "    train_dataset=train_dataset.select_columns(\n",
-    "        [\"positive\", \"anchor\"]\n",
+    "        [\"anchor\", \"positive\"]\n",
     "    ),  # training dataset\n",
     "    loss=train_loss,\n",
     "    evaluator=evaluator,\n",


### PR DESCRIPTION
Hello!

## Pull Request overview
* Update (positive, anchor) to (anchor, positive)

## Details
Some Sentence Transformers losses care about the order of the columns provided to the trainer, and the used `MultipleNegativesRankingLoss` is one of them. In essence, when you provide 2 columns, then it trains as:
* Given a value $X$ from the first column, which value from the second column (in this batch) is related to $X$?

If the first column is the answer, and the second column the question, then we train the model to find the question given the answer, not the other way around. This usually doesn't have a massive impact, but it can be a bit worse. 

Since the v3 release, I've added warnings to inform users when their column names are indicative that they're incorrectly ordered, but I think your users aren't noticing them (you expect a tutorial to be 100% correct after all).

- Tom Aarsen