### PR TITLE
Fixed typo in fine-tune-embedding-model-for-rag.ipynb

### DIFF
--- a/training/fine-tune-embedding-model-for-rag.ipynb
+++ b/training/fine-tune-embedding-model-for-rag.ipynb
@@ -100,7 +100,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We are going to load our open-source dataset using the 🤗 Datasets library, rename the colums to match what `sentence-transforemrs` expects and then split our dataset into a train and test spilt to be able to evaluate our model. "
+    "We are going to load our open-source dataset using the 🤗 Datasets library, rename the colums to match what `sentence-transformers` expects and then split our dataset into a train and test spilt to be able to evaluate our model. "
    ]
   },
   {


### PR DESCRIPTION
fixing a "crucial" typo `sentence-transforemrs`-> `sentence-transformers`