### PR TITLE
Added crucial comment in fine-tune-embedding-model-for-rag.ipynb

### DIFF
--- a/training/fine-tune-embedding-model-for-rag.ipynb
+++ b/training/fine-tune-embedding-model-for-rag.ipynb
@@ -169,7 +169,7 @@
     "    model_id, device=\"cuda\" if torch.cuda.is_available() else \"cpu\"\n",
     ")\n",
     "\n",
-    "# load test dataset\n",
+    "# Load the datasets (both are treated as 'train' splits when loaded from JSON)\n",
     "test_dataset = load_dataset(\"json\", data_files=\"test_dataset.json\", split=\"train\")\n",
     "train_dataset = load_dataset(\"json\", data_files=\"train_dataset.json\", split=\"train\")\n",
     "corpus_dataset = concatenate_datasets([train_dataset, test_dataset])\n",


### PR DESCRIPTION
- added a valuable comment, as one codesnippet was really confusing, as we used the test and train-splits for the document pool but we have to treat both as `train` splits, when loading from JSON, because there wouldn't be a predefined split called `test`. **Summary:** The code is correct but it looks like a typo when having to variables `test_dataset` and `train_dataset` but both use the split `train`